### PR TITLE
libcameraservice: Add support for miui camera mode

### DIFF
--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -38,6 +38,7 @@
 #include <aidl/AidlCameraService.h>
 #include <android-base/macros.h>
 #include <android-base/parseint.h>
+#include <android-base/properties.h>
 #include <android/permission/PermissionChecker.h>
 #include <binder/ActivityManager.h>
 #include <binder/AppOpsManager.h>
@@ -107,6 +108,7 @@ namespace android {
 using namespace camera3;
 using namespace camera3::SessionConfigurationUtils;
 
+using base::SetProperty;
 using binder::Status;
 using frameworks::cameraservice::service::V2_0::implementation::HidlCameraService;
 using frameworks::cameraservice::service::implementation::AidlCameraService;
@@ -4210,6 +4212,15 @@ status_t CameraService::BasicClient::startCameraOps() {
     }
 
     mOpsActive = true;
+
+    // Configure miui camera mode
+    if (strcmp(mClientPackageName.c_str(), "com.android.camera") == 0) {
+        SetProperty("sys.camera.miui.apk", "1");
+        ALOGI("Enabling miui camera mode");
+    } else {
+        SetProperty("sys.camera.miui.apk", "0");
+        ALOGI("Disabling miui camera mode");
+    }
 
     // Transition device availability listeners from PRESENT -> NOT_AVAILABLE
     sCameraService->updateStatus(StatusInternal::NOT_AVAILABLE, mCameraIdStr);


### PR DESCRIPTION
 * devices like ginkgo and some xiaomi sdm660 use miui camera mode in camera hal to activate certain functions in camera hal, these are enabled when vendor.camera.miui.apk is set to 1 based on sys.camera.miui.apk value

 * if this prop is set by default gcam crashes, so we must do it dynamically

 * xiaomi does this in stock libcameraservice but unfortunately we don't have stock android 12 to use prebuilt lib

[garry-rogov 2024-03-31]
 * updated for android 14 QPR2